### PR TITLE
Parse identifier with letters mixed with digits

### DIFF
--- a/lib/pubid/iec/parser.rb
+++ b/lib/pubid/iec/parser.rb
@@ -52,7 +52,7 @@ module Pubid::Iec
 
     rule(:number) do
       (digits | str("SYMBOL") | str("SYCSMARTENERGY") | str("SyCLVDC") |
-        str("SYCLVDC") | str("SyCCOMM") | str("SyCAAL") | str("VIM") | match("[A-Za-z ]").repeat) >>
+        str("SYCLVDC") | str("SyCCOMM") | str("SyCAAL") | str("VIM") | match("[A-Za-z0-9 ]").repeat) >>
         ((str(":") >> match("[A-Z]").repeat(1)) | match("[A-Z]")).maybe
     end
 

--- a/spec/pubid_iec/identifier/base_spec.rb
+++ b/spec/pubid_iec/identifier/base_spec.rb
@@ -278,6 +278,36 @@ module Pubid::Iec
       it { expect(subject.language.map(&:to_s).sort).to eq(%w[en fr]) }
     end
 
+    context "IEC ACEE 01:2018" do
+      let(:pubid) { "IEC ACEE 01:2018" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "IEC GIORGI:2001" do
+      let(:pubid) { "IEC GIORGI:2001" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "IEC CENT-CHAL:2006" do
+      let(:pubid) { "IEC CENT-CHAL:2006" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "IEC HANDB1:1983" do
+      let(:pubid) { "IEC HANDB1:1983" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
+    context "ISO/IEC 20000-HBK:2019" do
+      let(:pubid) { "ISO/IEC 20000-HBK:2019" }
+
+      it_behaves_like "converts pubid to pubid"
+    end
+
     context "database identifier" do
       context "with DB and with year" do
         let(:original) { "IEC 60061:2022 DB" }


### PR DESCRIPTION
closes #14 

For all identifiers in the issue, I just parse a letter mixed with numbers as the identifier's number.
I checked every identifier on https://webstore.iec.ch and seems its right approach.
Only questionable is handbook identifiers:
- `IEC HANDB1:1983` (in description it refers to `IEC 60375`, so seems it handbook to `IEC 60375`)
- `ISO/IEC 20000-HBK:2019` (this is handbook to `ISO/IEC 20000:2019`)