### PR TITLE
Don't include "IS" to identifier's output

### DIFF
--- a/lib/pubid/iec/identifier/international_standard.rb
+++ b/lib/pubid/iec/identifier/international_standard.rb
@@ -66,7 +66,7 @@ module Pubid::Iec
       }.freeze
 
       def self.type
-        { key: :is, title: "International Standard", short: "IS" }
+        { key: :is, title: "International Standard", short: nil }
       end
     end
   end

--- a/pubid-iec.gemspec
+++ b/pubid-iec.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
 
   spec.add_dependency "parslet"
-  spec.add_dependency "pubid-core", "~> 1.12"
+  spec.add_dependency "pubid-core", "~> 1.12.2"
 end


### PR DESCRIPTION
related https://github.com/metanorma/pubid-core/issues/36